### PR TITLE
修了 cfp/news 頁面的兩個東西

### DIFF
--- a/src/assets/scss/news/agenda.scss
+++ b/src/assets/scss/news/agenda.scss
@@ -23,18 +23,11 @@ $max-width-small-3: 360px;
 @mixin infoContainer() {
   max-width: 80%;
   // padding-left: 7%;
-  @media only screen and (max-width: $max-width-small-0) {
-    // width: 89%;
-    max-width: 100%;
-    padding-left: 40px;
-    padding-right: 40px;
-  }
-  @media only screen and (max-width: $max-width-small-1) {
-    // width: 89%;
-    max-width: 100%;
-    padding-left: 40px;
-    padding-right: 40px;
-  }
+  @media only screen and (max-width: 1030px){
+      max-width: 100%;
+      padding-left: 40px;
+      padding-right: 40px;
+  } 
 }
 
 // .info-section

--- a/src/assets/scss/news/header.scss
+++ b/src/assets/scss/news/header.scss
@@ -31,18 +31,9 @@
           0px 0px 10px 0px rgba(0, 0, 0, 0.2);
 
         @keyframes jump {
-          0% {
-            position: relative;
-            bottom: 0px;
-          }
           50% {
-            position: relative;
-            bottom: 20px;
-          }
-          100% {
-            position: relative;
-            bottom: 0px;
-          }
+		    transform: translateY(-5px) rotate(45deg) ;
+	      } 
         }
 
         &:hover {

--- a/src/assets/scss/news/header.scss
+++ b/src/assets/scss/news/header.scss
@@ -32,7 +32,7 @@
 
         @keyframes jump {
           50% {
-		    transform: translateY(-5px) rotate(45deg) ;
+		    transform: translateY(-20px) rotate(45deg) ;
 	      } 
         }
 


### PR DESCRIPTION
（一）

原本 return-wrapper 當中的 shape-wrapper diamond 使用的 jump 是直接修改 bottom，很有可能導致修改完位置造成 unhover，會有按鈕抽動的現象，把 jump 修改成使用 translateY，就比較不會有這種事情發生。

（二）

在寬度不超過 1030px 的時候，news-schedule會變成：

#news-schedule {
    max-width: 100vw;
    padding: 0 40px;
    font-size: 11pt;
}

而 info-container 是

.info-container {
    max-width: 80%;
    margin: 0 auto;
}

會有對不上的情況，我修改了一下。

<img width="1026" alt="5" src="https://user-images.githubusercontent.com/30391069/105409301-38da0380-5c6b-11eb-884a-d7f2af87b79e.png">
