### PR TITLE
修了一些東西

### DIFF
--- a/src/assets/scss/CFP/intro.scss
+++ b/src/assets/scss/CFP/intro.scss
@@ -247,7 +247,21 @@
       padding-top: 0px;
       padding-bottom: 90px;
       // height: 1240px;
+    }
 
+    .box-back2 {
+      padding-top: 380px;
+
+      .give-me-money {
+        margin-top: 140px;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 646px)  {
+  #cfp-intro {
+    .box-back {  
       .past-sitcon {
         .cfp-img {
           width: 180px; //225
@@ -268,17 +282,8 @@
         }
       }
     }
-
-    .box-back2 {
-      padding-top: 380px;
-
-      .give-me-money {
-        margin-top: 140px;
-      }
-    }
   }
 }
-
 @media screen and (max-width: 540px)  {
   #cfp-intro {
     .box-back2 {

--- a/src/assets/scss/news/agenda.scss
+++ b/src/assets/scss/news/agenda.scss
@@ -23,7 +23,7 @@ $max-width-small-3: 360px;
 @mixin infoContainer() {
   max-width: 80%;
   // padding-left: 7%;
-  @media only screen and (max-width: 1030px){
+  @media only screen and (max-width: 767px){
       max-width: 100%;
       padding-left: 40px;
       padding-right: 40px;

--- a/src/assets/scss/news/header.scss
+++ b/src/assets/scss/news/header.scss
@@ -51,7 +51,7 @@
         }
       }
     }
-    @media screen and (min-width: 1023px) {
+    @media screen and (min-width: 1024px) {
     .contribute-wrapper {
         position:absolute;
         background-color: #ffffff;

--- a/src/assets/scss/news/schedule.scss
+++ b/src/assets/scss/news/schedule.scss
@@ -91,7 +91,8 @@ $fontFamily: 'Noto Sans CJK TC', monospace;
   font-weight: 900;
 }
 
-@include md {
+
+@media screen and (max-width: 767px) {
   #news-schedule {
     max-width: 100vw;
     padding: 0 40px;


### PR DESCRIPTION
在 cfp/news 頁面寬度為 1023px 時候會有顯示錯誤。

<img width="1428" alt="1023px" src="https://user-images.githubusercontent.com/30391069/105573212-e269e380-5d96-11eb-8d64-392b97e205d3.png">

在頁面寬度小於 1030px 的時候也沒有對齊，稍微修改了一下使其整體對齊。

<img width="1011" alt="1030px" src="https://user-images.githubusercontent.com/30391069/105573230-f6154a00-5d96-11eb-8b60-aaa6ac58b885.png">

在 cfp 頁面讓圖片排列變成 column 的條件改成 646 px，這是 breakpoint.scss 中的斷點，和 hyperpoint 不太一樣，覺得這個設為 646px 比較合理。
